### PR TITLE
Add CD trimming hyperparameter

### DIFF
--- a/experiments/cifar10/config_multigpu.py
+++ b/experiments/cifar10/config_multigpu.py
@@ -58,6 +58,11 @@ def define_flags():
     flags.DEFINE_float("time_cutoff", 1.0, "Flow loss decays to zero beyond t>=time_cutoff")
     flags.DEFINE_float("cd_neg_clamp", 1.0,
                        "Clamp negative total CD below -cd_neg_clamp. 0=disable clamp.")
+    flags.DEFINE_float(
+        "cd_trim_fraction",
+        0.2,
+        "Fraction of highest negative energies discarded for CD (0=disable).",
+    )
     flags.DEFINE_float("cd_loss_threshold", 0.1, "Threshold value for negative cd_loss at which we increase MCMC difficulty")
     flags.DEFINE_bool("split_negative", False, "If True, initialize half of the negative samples from x_real_cd, half from noise")
 

--- a/experiments/imagenet32/config_multigpu_imagenet32.py
+++ b/experiments/imagenet32/config_multigpu_imagenet32.py
@@ -56,6 +56,11 @@ def define_flags():
     flags.DEFINE_float("time_cutoff", 1.0, "Flow loss decays to zero beyond t>=time_cutoff")
     flags.DEFINE_float("cd_neg_clamp", 0.002,
                        "Clamp negative total CD below -cd_neg_clamp. 0=disable clamp.")
+    flags.DEFINE_float(
+        "cd_trim_fraction",
+        0.2,
+        "Fraction of highest negative energies discarded for CD (0=disable).",
+    )
     flags.DEFINE_float("cd_loss_threshold", 10., "Threshold value for negative cd_loss at which we increase MCMC difficulty")
     flags.DEFINE_bool("split_negative", False, "If True, initialize half of the negative samples from x_real_cd, half from noise")
 


### PR DESCRIPTION
## Summary
- add `cd_trim_fraction` to CIFAR-10 and ImageNet32 configs
- trim high negative energies in CIFAR-10 training
- parameterize trimming in ImageNet32 training

## Testing
- `python -m py_compile experiments/cifar10/config_multigpu.py experiments/cifar10/train_cifar_multigpu.py experiments/imagenet32/config_multigpu_imagenet32.py experiments/imagenet32/train_imagenet_multigpu.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684758ec618883268f9b2afda3a2725a