### PR TITLE
Add step-numbered checkpoints

### DIFF
--- a/experiments/cifar10/train_cifar_multigpu.py
+++ b/experiments/cifar10/train_cifar_multigpu.py
@@ -373,18 +373,23 @@ def train_loop(rank, world_size, argv):
                 # (c) Save side-by-side grids
                 save_pos_neg_grids(real_batch, x_neg, savedir, step)
 
-                ckpt_path = os.path.join(savedir, f"{FLAGS.model}_cifar10_weights_step_latest.pt")
-                torch.save(
-                    {
-                        "net_model": net_model.module.state_dict(),
-                        "ema_model": ema_model.state_dict(),
-                        "sched": sched.state_dict(),
-                        "optim": optim.state_dict(),
-                        "step": step,
-                    },
-                    ckpt_path
-                )
-                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_path}")
+                ckpt_latest = os.path.join(savedir,
+                                          f"{FLAGS.model}_cifar10_weights_step_latest.pt")
+                ckpt_numbered = os.path.join(savedir, f"checkpoint_{step}.pt")
+
+                checkpoint_data = {
+                    "net_model": net_model.module.state_dict(),
+                    "ema_model": ema_model.state_dict(),
+                    "sched": sched.state_dict(),
+                    "optim": optim.state_dict(),
+                    "step": step,
+                }
+
+                torch.save(checkpoint_data, ckpt_latest)
+                torch.save(checkpoint_data, ckpt_numbered)
+
+                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_latest}")
+                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_numbered}")
 
     dist.barrier()
     dist.destroy_process_group()

--- a/experiments/imagenet32/train_imagenet_multigpu.py
+++ b/experiments/imagenet32/train_imagenet_multigpu.py
@@ -333,20 +333,24 @@ def train_loop(rank, world_size, argv):
                 )
                 save_pos_neg_grids(real_batch, x_neg, savedir, step)
 
-                ckpt_path = os.path.join(
+                ckpt_latest = os.path.join(
                     savedir, f"{FLAGS.model}_imagenet32_weights_step_latest.pt"
                 )
-                torch.save(
-                    {
-                        "net_model": net_model.module.state_dict(),
-                        "ema_model": ema_model.state_dict(),
-                        "optim": optim.state_dict(),
-                        "sched": sched.state_dict(),
-                        "step": step,
-                    },
-                    ckpt_path
-                )
-                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_path}")
+                ckpt_numbered = os.path.join(savedir, f"checkpoint_{step}.pt")
+
+                checkpoint_data = {
+                    "net_model": net_model.module.state_dict(),
+                    "ema_model": ema_model.state_dict(),
+                    "optim": optim.state_dict(),
+                    "sched": sched.state_dict(),
+                    "step": step,
+                }
+
+                torch.save(checkpoint_data, ckpt_latest)
+                torch.save(checkpoint_data, ckpt_numbered)
+
+                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_latest}")
+                logging.info(f"[Rank 0] Saved checkpoint => {ckpt_numbered}")
 
     dist.barrier()
     dist.destroy_process_group()


### PR DESCRIPTION
## Summary
- write checkpoint files with a unique `checkpoint_<step>.pt` name during training
- update CIFAR10 and ImageNet32 training scripts accordingly

## Testing
- `python -m py_compile experiments/cifar10/train_cifar_multigpu.py experiments/imagenet32/train_imagenet_multigpu.py`

------
https://chatgpt.com/codex/tasks/task_e_6848355246b883268e20b03c24de5057