### PR TITLE
Add optional flow loss weighting in toy example

### DIFF
--- a/experiments/toy2d/tutorial_2D.ipynb
+++ b/experiments/toy2d/tutorial_2D.ipynb
@@ -94,6 +94,7 @@
         "ebm_loss_weight = 1.0\n",
         "sigma = 0.1\n",
         "save_dir = \"2D_toy\"\n",
+        "use_flow_weighting = True  # optional phase 2 flow weight annealing near t=1 for regularization\n",
         "\n",
         "# Noise schedule hyperparams\n",
         "tau_star = 0.8       # time at which temperature > 0 begins\n",
@@ -111,7 +112,8 @@
         "    sigma=sigma,\n",
         "    save_dir=save_dir,\n",
         "    tau_star=tau_star,\n",
-        "    epsilon_max=epsilon_max\n",
+        "    epsilon_max=epsilon_max,\n",
+        "    use_flow_weighting=use_flow_weighting\n",
         ")"
       ]
     },


### PR DESCRIPTION
## Summary
- add `flow_weight_schedule` for time-dependent flow regularization
- allow `train` to apply flow weighting via `use_flow_weighting` parameter
- expose the option in the 2D tutorial notebook
- default to using flow weighting in the tutorial

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685033ef2a2483269dcd25a3ea2fdf35