### PR TITLE
Add same_temperature_scheduler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ torchrun --nproc_per_node=4 experiments/cifar10/train_cifar_multigpu.py \
     --save_step 100 \
     --dt_gibbs 0.01 \
     --cd_neg_clamp 0.02  \
-    --split_negative=True \
+    --split_negative True \
+    --same_temperature_scheduler True \
     --save_step 100
 ```
 Evaluation across trajectories at times `T=1.0` to `T=5.0`:

--- a/experiments/cifar10/config_multigpu.py
+++ b/experiments/cifar10/config_multigpu.py
@@ -64,6 +64,11 @@ def define_flags():
         "Fraction of highest negative energies discarded for CD (0=disable).",
     )
     flags.DEFINE_bool("split_negative", False, "If True, initialize half of the negative samples from x_real_cd, half from noise")
+    flags.DEFINE_bool(
+        "same_temperature_scheduler",
+        True,
+        "If True, ignore at_data_mask and use the same temperature schedule for all samples",
+    )
 
 
     # Optional log dir

--- a/experiments/cifar10/train_cifar_multigpu.py
+++ b/experiments/cifar10/train_cifar_multigpu.py
@@ -120,6 +120,9 @@ def forward_all(model,
             x_neg_init = torch.randn_like(x_real_cd)
             at_data_mask = torch.zeros(x_real_cd.size(0), dtype=torch.bool, device=device)
 
+        if FLAGS.same_temperature_scheduler:
+            at_data_mask = torch.zeros_like(at_data_mask)
+
         x_neg = gibbs_sampling_time_sweep(
             x_init=x_neg_init,
             model=model.module,


### PR DESCRIPTION
## Summary
- allow disabling per-sample temperature schedule in CIFAR training
- expose `--same_temperature_scheduler` flag (default True)
- show flag usage in Algorithm 2 command
- use consistent style for `split_negative` flag

## Testing
- `python -m py_compile experiments/cifar10/config_multigpu.py experiments/cifar10/train_cifar_multigpu.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851852586408326ab4b497eb7da4d39