### PR TITLE
Fix GPU selection for DDP training

### DIFF
--- a/experiments/cifar10/train_cifar_multigpu.py
+++ b/experiments/cifar10/train_cifar_multigpu.py
@@ -167,8 +167,8 @@ def train_loop(rank, world_size, argv):
     # -----------------------------------------------------------------------
     # 0) Init distributed
     # -----------------------------------------------------------------------
-    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     torch.cuda.set_device(rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
     device = torch.device(f"cuda:{rank}")
 
     # -----------------------------------------------------------------------
@@ -421,8 +421,8 @@ def train_loop(rank, world_size, argv):
 
 
 def main(argv):
-    world_size = torch.cuda.device_count()
-    rank = int(os.environ.get("RANK", 0))  # or local_rank
+    world_size = int(os.environ.get("WORLD_SIZE", torch.cuda.device_count()))
+    rank = int(os.environ.get("RANK", 0))
     train_loop(rank, world_size, argv)
 
 


### PR DESCRIPTION
## Summary
- initialize CUDA device before creating the process group
- derive `WORLD_SIZE` from environment variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68518fb342888326a0b5474d4f7afe9f